### PR TITLE
Visualizar História do edifício selecionado

### DIFF
--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -70,31 +70,37 @@
         android:orientation="vertical"
         android:padding="10dp">
 
-
-        <TextView
-            android:id="@+id/text_history_title"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_marginBottom="10dp"
-            android:fontFamily="@font/raullinofonte"
-            android:text="ASSEMBLEIA DE ABRANTES"
-            android:textAlignment="textStart"
-            android:textColor="#272133"
-            android:textSize="20sp" />
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
 
+            <TextView
+                android:id="@+id/text_history_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:layout_marginBottom="10dp"
+                android:fontFamily="@font/raullinofonte"
+                android:text="ASSEMBLEIA DE ABRANTES"
+                android:textAlignment="textStart"
+                android:textColor="#272133"
+                android:textSize="20sp" />
 
+            <ImageButton
+                android:id="@+id/my_button"
+                android:layout_width="290dp"
+                android:layout_height="49dp"
+                android:layout_margin="8dp"
+                android:background="@null"
+                android:contentDescription="Botão para apagar"
+                android:scaleType="fitCenter"
+                android:src="@drawable/icon_apagar"
+                android:textSize="16sp" />
 
-        <ImageButton
-            android:id="@+id/my_button"
-            android:layout_width="610dp"
-            android:layout_height="49dp"
-            android:layout_margin="8dp"
-            android:background="@null"
-            android:scaleType="fitCenter"
-            android:src="@drawable/icon_apagar"
-            android:text="Meu Botão"
-            android:textSize="16sp" />
+        </LinearLayout>
+
 
         <ImageView
             android:id="@+id/imageView"


### PR DESCRIPTION
Ajuste no design para o botão ficar lado a lado com titulo do edifício selecionado